### PR TITLE
新機能「ポテンシャル解放」を対応

### DIFF
--- a/Cindeck.Core/AppConfig.cs
+++ b/Cindeck.Core/AppConfig.cs
@@ -15,6 +15,7 @@ namespace Cindeck.Core
     public class AppConfig
     {
         private static DataContractSerializer m_serializer= new DataContractSerializer(typeof(AppConfig),new DataContractSerializerSettings{ PreserveObjectReferences=true  });
+        private static AppConfig m_current = null;
 
         private AppConfig()
         {
@@ -36,6 +37,7 @@ namespace Cindeck.Core
                  new SortOption { Column=nameof(IIdol.Rarity), Direction=ListSortDirection.Descending },
                 new SortOption { Column=nameof(IIdol.ImplementationDate), Direction=ListSortDirection.Descending }
             };
+
             NextOid = 1;
         }
 
@@ -119,6 +121,27 @@ namespace Cindeck.Core
             set;
         }
 
+        [DataMember(Order = 12)]
+        public ObservableCollection<Potential> PotentialData
+        {
+            get;
+            set;
+        }
+
+        [DataMember(Order = 13)]
+        public FilterConfig PotentialFilterConfig
+        {
+            get;
+            set;
+        }
+
+        [DataMember(Order = 14)]
+        public List<SortOption> PotentialSortOptions
+        {
+            get;
+            set;
+        }
+
         public int GetNextLid()
         {
             return NextOid++;
@@ -133,16 +156,68 @@ namespace Cindeck.Core
             }  
         }
 
+        public static AppConfig Current
+        {
+            get
+            {
+                return m_current;
+            }
+        }
+
         public static AppConfig Load()
         {
+            AppConfig config = null;
             if(!File.Exists("app.config"))
             {
-                return new AppConfig();
+                config = new AppConfig();
             }
-            using (var fs = File.OpenRead("app.config"))
+            else
             {
-                return (AppConfig)m_serializer.ReadObject(fs);
+                using (var fs = File.OpenRead("app.config"))
+                {
+                    config = (AppConfig)m_serializer.ReadObject(fs);
+                }
             }
+
+            if (config.PotentialData == null)
+            {
+                config.PotentialData = new ObservableCollection<Potential>();
+            }
+
+            if (config.ImplementedIdols.Count > 0 && config.PotentialData.Count == 0)
+            {
+                var idolList = config.ImplementedIdols.GroupBy(x => x.Name)
+                    .Select(x => new Potential { Category = x.First().Category, Name = x.Key });
+
+                foreach (var x in idolList)
+                {
+                    config.PotentialData.Add(x);
+                }
+            }
+
+            config.ImplementedIdols.CollectionChanged += (sender, e) =>
+            {
+                if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add)
+                {
+                    foreach (var idol in e.NewItems.OfType<Idol>())
+                    {
+                        if (!config.PotentialData.Any(x => x.Name == idol.Name))
+                        {
+                            config.PotentialData.Add(new Potential { Category = idol.Category, Name = idol.Name });
+                        }
+                    }
+                }
+            };
+
+            if(config.PotentialSortOptions==null)
+            {
+                config.PotentialSortOptions = new List<SortOption>()
+                {
+                     new SortOption { Column=nameof(IIdol.Name), Direction=ListSortDirection.Ascending }
+                };
+            }
+
+            return m_current = config;
         }
 
         public static void Reset()

--- a/Cindeck.Core/AppConfig.cs
+++ b/Cindeck.Core/AppConfig.cs
@@ -41,7 +41,7 @@ namespace Cindeck.Core
             NextOid = 1;
         }
 
-        public string Version => "v1.7.1";
+        public string Version => "v1.8";
 
         [DataMember(Order = 1)]
         private int NextOid

--- a/Cindeck.Core/Cindeck.Core.csproj
+++ b/Cindeck.Core/Cindeck.Core.csproj
@@ -70,6 +70,7 @@
     <Compile Include="IIdolSource.cs" />
     <Compile Include="ISkill.cs" />
     <Compile Include="NoteJudgement.cs" />
+    <Compile Include="Potential.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RandomFactory.cs" />
     <Compile Include="Rarity.cs" />

--- a/Cindeck.Core/OwnedIdol.cs
+++ b/Cindeck.Core/OwnedIdol.cs
@@ -10,7 +10,7 @@ namespace Cindeck.Core
 {
     [DataContract(IsReference = true)]
     [ImplementPropertyChanged]
-    public class OwnedIdol:IIdol
+    public class OwnedIdol : IIdol
     {
         [DataMember]
         private Idol Idol
@@ -19,7 +19,7 @@ namespace Cindeck.Core
             set;
         }
 
-        public OwnedIdol(int lid, Idol idol, int skillLevel=10)
+        public OwnedIdol(int lid, Idol idol, int skillLevel = 10)
         {
             Oid = lid;
             Idol = idol;
@@ -29,8 +29,6 @@ namespace Cindeck.Core
         public IdolCategory Category => Idol.Category;
 
         public ICenterEffect CenterEffect => Idol.CenterEffect;
-
-        public int Dance => Idol.Dance;
 
         public int Iid => Idol.Iid;
 
@@ -43,8 +41,6 @@ namespace Cindeck.Core
         {
             get; private set;
         }
-
-        public int Life => Idol.Life;
 
         public string Name => Idol.Name;
 
@@ -63,15 +59,25 @@ namespace Cindeck.Core
 
         public double SkillScore => Skill.CalculateSkillScore(SkillLevel);
 
-        public int TotalAppeal => Idol.TotalAppeal;
+        public int TotalAppeal => Vocal + Dance + Visual;
 
-        public int Visual => Idol.Visual;
+        [DependsOn(nameof(Timestamp))]
+        public int Vocal => Idol.GetVocalWithPotential();
 
-        public int Vocal => Idol.Vocal;
+        [DependsOn(nameof(Timestamp))]
+        public int Dance => Idol.GetDanceWithPotential();
+
+        [DependsOn(nameof(Timestamp))]
+        public int Visual => Idol.GetVisualWithPotential();
+
+        [DependsOn(nameof(Timestamp))]
+        public int Life => Idol.GetLifeWithPotential();
+
+        public DateTime Timestamp { get; set; }
 
         public void UpdateReference(Idol idol)
         {
-            if(idol.Iid!=Idol.Iid)
+            if (idol.Iid != Idol.Iid)
             {
                 throw new Exception("Cannot update reference to an idol with different IID.");
             }

--- a/Cindeck.Core/Potential.cs
+++ b/Cindeck.Core/Potential.cs
@@ -1,0 +1,97 @@
+﻿using PropertyChanged;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cindeck.Core
+{
+    [ImplementPropertyChanged]
+    public class Potential:IIdol, INotifyPropertyChanged
+    {
+        public string Name { get; set; }
+
+        public IdolCategory Category { get; set; }
+
+        public int Vocal { get; set; }
+
+        public int Dance { get; set; }
+
+        public int Visual { get; set; }
+
+        public int Life { get; set; }
+
+        public ICenterEffect CenterEffect
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public int Iid
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public DateTime ImplementationDate
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public string Label
+        {
+            get
+            {
+                return Name;
+            }
+        }
+
+        public string LabeledName
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public Rarity Rarity
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public ISkill Skill
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public int TotalAppeal
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        public void OnPropertyChanged(string propertyName, object before, object after)
+        {
+            if(PropertyChanged!=null) PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Cindeck.Core/Simulator.cs
+++ b/Cindeck.Core/Simulator.cs
@@ -115,10 +115,18 @@ namespace Cindeck.Core
         public Simulator(AppConfig config)
         {
             m_config = config;
+            GuestPotential = new Potential();
+            GuestPotential.PropertyChanged += (s, e) => Reload();
             GrooveType = IdolCategory.Cute;
         }
 
         public Idol Guest
+        {
+            get;
+            set;
+        }
+
+        public Potential GuestPotential
         {
             get;
             set;
@@ -540,12 +548,20 @@ namespace Cindeck.Core
                 CalculateAppeal(AppealType.Visual, idol, isSupportMember, encore);
         }
 
+        private Idol CreateGuestWithPotential(IIdol guest)
+        {
+            return guest == null ? null : new Idol(guest.Label, guest.Name, guest.Rarity, guest.Category, guest.GetLifeWithPotential(GuestPotential), guest.GetDanceWithPotential(GuestPotential),
+                guest.GetVocalWithPotential(GuestPotential), guest.GetVisualWithPotential(GuestPotential), guest.ImplementationDate, guest.CenterEffect, guest.Skill);
+        }
+
         public void Reload()
         {
+            var guest = CreateGuestWithPotential(Guest);
             SupportMembers = SelectSupportMembers();
             SupportMemberAppeal = SupportMembers.Sum(x => CalculateAppeal(x, true, IsEncore));
-            TotalAppeal = SupportMemberAppeal + Unit.GetValueOrDefault(u => u.Slots.Sum(x => CalculateAppeal(x, false, IsEncore))) + CalculateAppeal(Guest, false, IsEncore);
-            Life = CalculateLife(Unit, Guest);
+            
+            TotalAppeal = SupportMemberAppeal + Unit.GetValueOrDefault(u => u.Slots.Sum(x => CalculateAppeal(x, false, IsEncore))) + CalculateAppeal(guest, false, IsEncore);
+            Life = CalculateLife(Unit, guest);
             ResultsUpToDate = false;
         }
 

--- a/Cindeck.Core/Unit.cs
+++ b/Cindeck.Core/Unit.cs
@@ -19,14 +19,14 @@ namespace Cindeck.Core
             set;
         }
 
-        [DataMember]
+        [DataMember, DependsOn(nameof(Timestamp))]
         public OwnedIdol Slot1
         {
             get;
             set;
         }
 
-        [DataMember]
+        [DataMember, DependsOn(nameof(Timestamp))]
         public OwnedIdol Slot2
         {
             get;
@@ -36,21 +36,21 @@ namespace Cindeck.Core
         /// <summary>
         /// センターです
         /// </summary>
-        [DataMember]
+        [DataMember, DependsOn(nameof(Timestamp))]
         public OwnedIdol Slot3
         {
             get;
             set;
         }
 
-        [DataMember]
+        [DataMember, DependsOn(nameof(Timestamp))]
         public OwnedIdol Slot4
         {
             get;
             set;
         }
 
-        [DataMember]
+        [DataMember, DependsOn(nameof(Timestamp))]
         public OwnedIdol Slot5
         {
             get;
@@ -64,6 +64,8 @@ namespace Cindeck.Core
                 return Slot3;
             }
         }
+
+        public DateTime Timestamp { get; set; }
 
         [DependsOn("Slot1", "Slot2", "Slot3", "Slot4", "Slot5")]
         public IEnumerable<OwnedIdol> Slots

--- a/Cindeck.Core/Utils.cs
+++ b/Cindeck.Core/Utils.cs
@@ -152,6 +152,8 @@ namespace Cindeck.Core
             { 10,new Dictionary<Rarity, int> { { Rarity.N,13 }, { Rarity.NPlus, 13 }, { Rarity.R, 14 }, { Rarity.RPlus, 14 }, { Rarity.SR, 20 }, { Rarity.SRPlus, 20 }, { Rarity.SSR, 22 }, { Rarity.SSRPlus, 22 } } },
         };
 
+        private static Dictionary<string, Potential> m_potentialDataCache = new Dictionary<string, Potential>();
+
         public static string ToLocalizedString(this SkillTriggerProbability pos)
         {
             return m_posNames[pos];
@@ -313,24 +315,33 @@ namespace Cindeck.Core
             return expectedTriggerCount * skill.EstimateDuration(skillLv) * notesPerSecond * rate;
         }
 
+        private static Potential GetPotential(string idolName)
+        {
+            if(m_potentialDataCache.ContainsKey(idolName))
+            {
+                return m_potentialDataCache[idolName];
+            }
+            return m_potentialDataCache[idolName] = AppConfig.Current.PotentialData.First(x => x.Name == idolName);
+        }
+
         public static int GetVocalWithPotential(this IIdol idol, Potential potential = null)
         {
-            return idol.Vocal + m_potentialAppealDelta[(potential ?? AppConfig.Current.PotentialData.First(x => x.Name == idol.Name)).Vocal][idol.Rarity];
+            return idol.Vocal + m_potentialAppealDelta[(potential ?? GetPotential(idol.Name)).Vocal][idol.Rarity];
         }
 
         public static int GetDanceWithPotential(this IIdol idol, Potential potential = null)
         {
-            return idol.Dance + m_potentialAppealDelta[(potential ?? AppConfig.Current.PotentialData.First(x => x.Name == idol.Name)).Dance][idol.Rarity];
+            return idol.Dance + m_potentialAppealDelta[(potential ?? GetPotential(idol.Name)).Dance][idol.Rarity];
         }
 
         public static int GetVisualWithPotential(this IIdol idol, Potential potential = null)
         {
-            return idol.Visual + m_potentialAppealDelta[(potential ?? AppConfig.Current.PotentialData.First(x => x.Name == idol.Name)).Visual][idol.Rarity];
+            return idol.Visual + m_potentialAppealDelta[(potential ?? GetPotential(idol.Name)).Visual][idol.Rarity];
         }
 
         public static int GetLifeWithPotential(this IIdol idol, Potential potential = null)
         {
-            return idol.Life + m_potentialLifeDelta[(potential??AppConfig.Current.PotentialData.First(x => x.Name == idol.Name)).Life][idol.Rarity];
+            return idol.Life + m_potentialLifeDelta[(potential?? GetPotential(idol.Name)).Life][idol.Rarity];
         }
     }
 }

--- a/Cindeck.Core/Utils.cs
+++ b/Cindeck.Core/Utils.cs
@@ -122,6 +122,36 @@ namespace Cindeck.Core
             {SkillDuration.Instantaneous,2 },
         };
 
+        private static readonly Dictionary<int,Dictionary<Rarity,int>> m_potentialAppealDelta=new Dictionary<int, Dictionary<Rarity, int>>
+        {
+            { 0,new Dictionary<Rarity, int> { { Rarity.N,0 }, { Rarity.NPlus, 0 }, { Rarity.R, 0 }, { Rarity.RPlus, 0 }, { Rarity.SR, 0 }, { Rarity.SRPlus, 0 }, { Rarity.SSR, 0 }, { Rarity.SSRPlus, 0 } } },
+            { 1,new Dictionary<Rarity, int> { { Rarity.N,80 }, { Rarity.NPlus, 80 }, { Rarity.R, 60 }, { Rarity.RPlus, 60 }, { Rarity.SR, 60 }, { Rarity.SRPlus, 60 }, { Rarity.SSR, 40 }, { Rarity.SSRPlus, 40 } } },
+            { 2,new Dictionary<Rarity, int> { { Rarity.N,160 }, { Rarity.NPlus, 160 }, { Rarity.R, 120 }, { Rarity.RPlus, 120 }, { Rarity.SR, 120 }, { Rarity.SRPlus, 120 }, { Rarity.SSR, 80 }, { Rarity.SSRPlus, 80 } } },
+            { 3,new Dictionary<Rarity, int> { { Rarity.N,250 }, { Rarity.NPlus, 250 }, { Rarity.R, 180 }, { Rarity.RPlus, 180 }, { Rarity.SR, 180 }, { Rarity.SRPlus, 180 }, { Rarity.SSR, 120 }, { Rarity.SSRPlus, 120 } } },
+            { 4,new Dictionary<Rarity, int> { { Rarity.N,340 }, { Rarity.NPlus, 340 }, { Rarity.R, 255 }, { Rarity.RPlus, 255 }, { Rarity.SR, 250 }, { Rarity.SRPlus, 250 }, { Rarity.SSR, 170 }, { Rarity.SSRPlus, 170 } } },
+            { 5,new Dictionary<Rarity, int> { { Rarity.N,440 }, { Rarity.NPlus, 440 }, { Rarity.R, 330 }, { Rarity.RPlus, 330 }, { Rarity.SR, 320 }, { Rarity.SRPlus, 320 }, { Rarity.SSR, 220 }, { Rarity.SSRPlus, 220 } } },
+            { 6,new Dictionary<Rarity, int> { { Rarity.N,540 }, { Rarity.NPlus, 540 }, { Rarity.R, 405 }, { Rarity.RPlus, 405 }, { Rarity.SR, 390 }, { Rarity.SRPlus, 390 }, { Rarity.SSR, 270 }, { Rarity.SSRPlus, 270 } } },
+            { 7,new Dictionary<Rarity, int> { { Rarity.N,650 }, { Rarity.NPlus, 650 }, { Rarity.R, 480 }, { Rarity.RPlus, 480 }, { Rarity.SR, 460 }, { Rarity.SRPlus, 460 }, { Rarity.SSR, 320 }, { Rarity.SSRPlus, 320 } } },
+            { 8,new Dictionary<Rarity, int> { { Rarity.N,760 }, { Rarity.NPlus, 760 }, { Rarity.R, 570 }, { Rarity.RPlus, 570 }, { Rarity.SR, 540 }, { Rarity.SRPlus, 540 }, { Rarity.SSR, 380 }, { Rarity.SSRPlus, 380 } } },
+            { 9,new Dictionary<Rarity, int> { { Rarity.N,880 }, { Rarity.NPlus, 880 }, { Rarity.R, 660 }, { Rarity.RPlus, 660 }, { Rarity.SR, 620 }, { Rarity.SRPlus, 620 }, { Rarity.SSR, 440 }, { Rarity.SSRPlus, 440 } } },
+            { 10,new Dictionary<Rarity, int> { { Rarity.N,1000 }, { Rarity.NPlus, 1000 }, { Rarity.R, 750 }, { Rarity.RPlus, 750 }, { Rarity.SR, 700 }, { Rarity.SRPlus, 700 }, { Rarity.SSR, 500 }, { Rarity.SSRPlus, 500 } } },
+        };
+
+        private static readonly Dictionary<int, Dictionary<Rarity, int>> m_potentialLifeDelta = new Dictionary<int, Dictionary<Rarity, int>>
+        {
+            { 0,new Dictionary<Rarity, int> { { Rarity.N,0 }, { Rarity.NPlus, 0 }, { Rarity.R, 0 }, { Rarity.RPlus, 0 }, { Rarity.SR, 0 }, { Rarity.SRPlus, 0 }, { Rarity.SSR, 0 }, { Rarity.SSRPlus, 0 } } },
+            { 1,new Dictionary<Rarity, int> { { Rarity.N,1 }, { Rarity.NPlus, 1 }, { Rarity.R, 1 }, { Rarity.RPlus, 1 }, { Rarity.SR, 1 }, { Rarity.SRPlus, 1 }, { Rarity.SSR, 1 }, { Rarity.SSRPlus, 1 } } },
+            { 2,new Dictionary<Rarity, int> { { Rarity.N,2 }, { Rarity.NPlus, 2 }, { Rarity.R, 2 }, { Rarity.RPlus, 2 }, { Rarity.SR, 2 }, { Rarity.SRPlus, 2 }, { Rarity.SSR, 2 }, { Rarity.SSRPlus, 2 } } },
+            { 3,new Dictionary<Rarity, int> { { Rarity.N,3 }, { Rarity.NPlus, 3 }, { Rarity.R, 3 }, { Rarity.RPlus, 3 }, { Rarity.SR, 4 }, { Rarity.SRPlus, 4 }, { Rarity.SSR, 4 }, { Rarity.SSRPlus, 4 } } },
+            { 4,new Dictionary<Rarity, int> { { Rarity.N,4 }, { Rarity.NPlus, 4 }, { Rarity.R, 4 }, { Rarity.RPlus, 4 }, { Rarity.SR, 6 }, { Rarity.SRPlus, 6 }, { Rarity.SSR, 6 }, { Rarity.SSRPlus, 6 } } },
+            { 5,new Dictionary<Rarity, int> { { Rarity.N,5 }, { Rarity.NPlus, 5 }, { Rarity.R, 5 }, { Rarity.RPlus, 5 }, { Rarity.SR, 8 }, { Rarity.SRPlus, 8 }, { Rarity.SSR, 8 }, { Rarity.SSRPlus, 8 } } },
+            { 6,new Dictionary<Rarity, int> { { Rarity.N,6 }, { Rarity.NPlus, 6 }, { Rarity.R, 6 }, { Rarity.RPlus, 6 }, { Rarity.SR, 10 }, { Rarity.SRPlus, 10 }, { Rarity.SSR, 10 }, { Rarity.SSRPlus, 10 } } },
+            { 7,new Dictionary<Rarity, int> { { Rarity.N,7 }, { Rarity.NPlus, 7 }, { Rarity.R, 8 }, { Rarity.RPlus, 8 }, { Rarity.SR, 12 }, { Rarity.SRPlus, 12 }, { Rarity.SSR, 13 }, { Rarity.SSRPlus, 13 } } },
+            { 8,new Dictionary<Rarity, int> { { Rarity.N,9 }, { Rarity.NPlus, 9 }, { Rarity.R, 10 }, { Rarity.RPlus, 10 }, { Rarity.SR, 14 }, { Rarity.SRPlus, 14 }, { Rarity.SSR, 16 }, { Rarity.SSRPlus, 16 } } },
+            { 9,new Dictionary<Rarity, int> { { Rarity.N,11 }, { Rarity.NPlus, 11 }, { Rarity.R, 12 }, { Rarity.RPlus, 12 }, { Rarity.SR, 17 }, { Rarity.SRPlus, 17 }, { Rarity.SSR, 19 }, { Rarity.SSRPlus, 19 } } },
+            { 10,new Dictionary<Rarity, int> { { Rarity.N,13 }, { Rarity.NPlus, 13 }, { Rarity.R, 14 }, { Rarity.RPlus, 14 }, { Rarity.SR, 20 }, { Rarity.SRPlus, 20 }, { Rarity.SSR, 22 }, { Rarity.SSRPlus, 22 } } },
+        };
+
         public static string ToLocalizedString(this SkillTriggerProbability pos)
         {
             return m_posNames[pos];
@@ -281,6 +311,26 @@ namespace Cindeck.Core
             var triggerCount=playTime / skill.Interval;
             var expectedTriggerCount = (int)Math.Floor(skill.EstimateProbability(skillLv) * triggerCount);
             return expectedTriggerCount * skill.EstimateDuration(skillLv) * notesPerSecond * rate;
+        }
+
+        public static int GetVocalWithPotential(this IIdol idol, Potential potential = null)
+        {
+            return idol.Vocal + m_potentialAppealDelta[(potential ?? AppConfig.Current.PotentialData.First(x => x.Name == idol.Name)).Vocal][idol.Rarity];
+        }
+
+        public static int GetDanceWithPotential(this IIdol idol, Potential potential = null)
+        {
+            return idol.Dance + m_potentialAppealDelta[(potential ?? AppConfig.Current.PotentialData.First(x => x.Name == idol.Name)).Dance][idol.Rarity];
+        }
+
+        public static int GetVisualWithPotential(this IIdol idol, Potential potential = null)
+        {
+            return idol.Visual + m_potentialAppealDelta[(potential ?? AppConfig.Current.PotentialData.First(x => x.Name == idol.Name)).Visual][idol.Rarity];
+        }
+
+        public static int GetLifeWithPotential(this IIdol idol, Potential potential = null)
+        {
+            return idol.Life + m_potentialLifeDelta[(potential??AppConfig.Current.PotentialData.First(x => x.Name == idol.Name)).Life][idol.Rarity];
         }
     }
 }

--- a/Cindeck/Cindeck.csproj
+++ b/Cindeck/Cindeck.csproj
@@ -79,6 +79,7 @@
     <Compile Include="ViewModels\ImplementedIdolViewModel.cs" />
     <Compile Include="ViewModels\MainViewModel.cs" />
     <Compile Include="ViewModels\OwnedIdolViewModel.cs" />
+    <Compile Include="ViewModels\PotentialViewModel.cs" />
     <Compile Include="ViewModels\SimulationViewModel.cs" />
     <Compile Include="ViewModels\UnitViewModel.cs" />
     <Compile Include="Views\ImplementedIdolView.xaml.cs">
@@ -86,6 +87,9 @@
     </Compile>
     <Compile Include="Views\OwnedIdolView.xaml.cs">
       <DependentUpon>OwnedIdolView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\PotentialView.xaml.cs">
+      <DependentUpon>PotentialView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\SimulationView.xaml.cs">
       <DependentUpon>SimulationView.xaml</DependentUpon>
@@ -126,6 +130,10 @@
       <SubType>Code</SubType>
     </Compile>
     <Page Include="Views\OwnedIdolView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\PotentialView.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Cindeck/Controls/IdolFilterPanel.xaml
+++ b/Cindeck/Controls/IdolFilterPanel.xaml
@@ -14,31 +14,31 @@
         </ResourceDictionary>
     </UserControl.Resources>
     <WrapPanel DockPanel.Dock="Left" Orientation="Horizontal">
-        <StackPanel Orientation="Horizontal">
+        <StackPanel Orientation="Horizontal" Visibility="{Binding EnableCategoryFilter, Converter={StaticResource BooleanToVisibilityConverter}}">
             <Label Content="タイプ"/>
             <ComboBox  Width="100" ItemsSource="{Binding IdolTypes}" DisplayMemberPath="Item2" SelectedValuePath="Item1" SelectedValue="{Binding TypeFilter, Mode=TwoWay}"/>
         </StackPanel>
 
-        <StackPanel Orientation="Horizontal">
+        <StackPanel Orientation="Horizontal" Visibility="{Binding EnableRarityFilter, Converter={StaticResource BooleanToVisibilityConverter}}">
             <Label Content="レア度"/>
             <ComboBox  Width="100" ItemsSource="{Binding Rarities}" DisplayMemberPath="Item2" SelectedValuePath="Item1" SelectedValue="{Binding RarityFilter, Mode=TwoWay}"/>
         </StackPanel>
 
-        <StackPanel Orientation="Horizontal">
+        <StackPanel Orientation="Horizontal" Visibility="{Binding EnableSkillFilter, Converter={StaticResource BooleanToVisibilityConverter}}">
             <Label Content="スキル"/>
             <ComboBox  Width="150" ItemsSource="{Binding Skills}" DisplayMemberPath="Item2" SelectedValuePath="Item1" SelectedValue="{Binding SkillFilter, Mode=TwoWay}"/>
         </StackPanel>
 
-        <StackPanel Orientation="Horizontal">
+        <StackPanel Orientation="Horizontal" Visibility="{Binding EnableCenterEffectFilter, Converter={StaticResource BooleanToVisibilityConverter}}">
             <Label Content="センター効果"/>
             <ComboBox  Width="150" ItemsSource="{Binding CenterEffects}" DisplayMemberPath="Item2" SelectedValuePath="Item1" SelectedValue="{Binding CenterEffectFilter, Mode=TwoWay}"/>
         </StackPanel>
 
-        <StackPanel Orientation="Horizontal">
+        <StackPanel Orientation="Horizontal" Visibility="{Binding EnableNameFilter, Converter={StaticResource BooleanToVisibilityConverter}}">
             <Label Content="名前"/>
             <TextBox Width="150" Text="{Binding NameFilter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
         </StackPanel>
 
-        <CheckBox Visibility="{Binding AllowFilterOwned, Converter={StaticResource BooleanToVisibilityConverter}}" Margin="5,0,0,0" VerticalAlignment="Center" IsChecked="{Binding FilterOwned, Mode=TwoWay}"  Content="所有済みのアイドルを表示しない"/>
+        <CheckBox Visibility="{Binding EnableOwnedFilter, Converter={StaticResource BooleanToVisibilityConverter}}" Margin="5,0,0,0" VerticalAlignment="Center" IsChecked="{Binding FilterOwned, Mode=TwoWay}"  Content="所有済みのアイドルを表示しない"/>
     </WrapPanel>
 </UserControl>

--- a/Cindeck/Resources.xaml
+++ b/Cindeck/Resources.xaml
@@ -63,4 +63,18 @@
         <sys:Int32>10</sys:Int32>
     </x:Array>
 
+    <x:Array Type="sys:Int32" x:Key="PotentialLevels">
+        <sys:Int32>0</sys:Int32>
+        <sys:Int32>1</sys:Int32>
+        <sys:Int32>2</sys:Int32>
+        <sys:Int32>3</sys:Int32>
+        <sys:Int32>4</sys:Int32>
+        <sys:Int32>5</sys:Int32>
+        <sys:Int32>6</sys:Int32>
+        <sys:Int32>7</sys:Int32>
+        <sys:Int32>8</sys:Int32>
+        <sys:Int32>9</sys:Int32>
+        <sys:Int32>10</sys:Int32>
+    </x:Array>
+
 </ResourceDictionary>

--- a/Cindeck/ViewModels/IdolFilter.cs
+++ b/Cindeck/ViewModels/IdolFilter.cs
@@ -15,12 +15,18 @@ namespace Cindeck.ViewModels
         private AppConfig m_config;
         private ICollectionView m_target;
 
-        public IdolFilter(AppConfig config, ICollectionView target, bool allowFilterOwned)
+        public IdolFilter(AppConfig config, ICollectionView target, bool enableOwnedFilter=true,
+            bool enableCategoryFilter=true, bool enableNameFilter=true, bool enableRarityFilter = true, bool enableCenterEffectFilter = true, bool enableSkillFilter = true)
         {
             m_config = config;
             m_target = target;
             target.Filter = FilterIdols;
-            AllowFilterOwned = allowFilterOwned;
+            EnableOwnedFilter = enableOwnedFilter;
+            EnableRarityFilter = enableRarityFilter;
+            EnableCenterEffectFilter = enableCenterEffectFilter;
+            EnableSkillFilter = enableSkillFilter;
+            EnableCategoryFilter = enableCategoryFilter;
+            EnableNameFilter = enableNameFilter;
 
             IdolTypes = new List<Tuple<IdolCategory, string>>
             {
@@ -113,7 +119,37 @@ namespace Cindeck.ViewModels
             set;
         }
 
-        public bool AllowFilterOwned
+        public bool EnableCategoryFilter
+        {
+            get;
+            set;
+        }
+
+        public bool EnableNameFilter
+        {
+            get;
+            set;
+        }
+
+        public bool EnableOwnedFilter
+        {
+            get;
+            set;
+        }
+
+        public bool EnableRarityFilter
+        {
+            get;
+            set;
+        }
+
+        public bool EnableCenterEffectFilter
+        {
+            get;
+            set;
+        }
+
+        public bool EnableSkillFilter
         {
             get;
             set;

--- a/Cindeck/ViewModels/MainViewModel.cs
+++ b/Cindeck/ViewModels/MainViewModel.cs
@@ -31,6 +31,7 @@ namespace Cindeck.ViewModels
             OwnedIdol = new OwnedIdolViewModel(m_config,Units);
             ImplementedIdol = new ImplementedIdolViewModel(m_config, OwnedIdol);
             Simulation = new SimulationViewModel(m_config);
+            Potential = new PotentialViewModel(m_config);
         }
 
         public OwnedIdolViewModel OwnedIdol
@@ -53,6 +54,11 @@ namespace Cindeck.ViewModels
             get;
         }
 
+        public PotentialViewModel Potential
+        {
+            get;
+        }
+
         public string Title => $"Cindeck {m_config.Version}";
 
 
@@ -61,6 +67,7 @@ namespace Cindeck.ViewModels
             OwnedIdol.Dispose();
             ImplementedIdol.Dispose();
             Units.Dispose();
+            Potential.Dispose();
             m_config.Save();
         }
 

--- a/Cindeck/ViewModels/OwnedIdolViewModel.cs
+++ b/Cindeck/ViewModels/OwnedIdolViewModel.cs
@@ -26,7 +26,7 @@ namespace Cindeck.ViewModels
             m_config = config;
             m_uvm = uvm;
             Idols = new ListCollectionView(config.OwnedIdols);
-            Filter = new IdolFilter(config, Idols, false);
+            Filter = new IdolFilter(config, Idols, enableOwnedFilter: false);
             Filter.SetConfig(config.OwnedIdolFilterConfig);
 
             foreach (var option in config.OwnedIdolSortOptions)
@@ -125,7 +125,7 @@ namespace Cindeck.ViewModels
 
         public void OnActivate()
         {
-            
+            Idols.Refresh();
         }
 
         public void OnDeactivate()

--- a/Cindeck/ViewModels/PotentialViewModel.cs
+++ b/Cindeck/ViewModels/PotentialViewModel.cs
@@ -1,0 +1,62 @@
+﻿using Cindeck.Core;
+using PropertyChanged;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace Cindeck.ViewModels
+{
+
+    [ImplementPropertyChanged]
+    class PotentialViewModel : IViewModel
+    {
+        private AppConfig m_config;
+
+
+        public PotentialViewModel(AppConfig config)
+        {
+            m_config = config;
+            PotentialData = new ListCollectionView(config.PotentialData);
+            Filter = new IdolFilter(config, PotentialData, enableCenterEffectFilter: false, enableOwnedFilter: false, enableRarityFilter: false, enableSkillFilter: false);
+            Filter.SetConfig(config.PotentialFilterConfig);
+
+            foreach (var option in config.PotentialSortOptions)
+            {
+                PotentialData.SortDescriptions.Add(option.ToSortDescription());
+            }
+        }
+
+        public ListCollectionView PotentialData
+        {
+            get;
+        }
+
+        public IdolFilter Filter
+        {
+            get;
+        }
+
+        public void OnActivate()
+        {
+
+        }
+
+        public void OnDeactivate()
+        {
+
+        }
+
+        public void Dispose()
+        {
+            m_config.PotentialSortOptions.Clear();
+            foreach (var x in PotentialData.SortDescriptions)
+            {
+                m_config.PotentialSortOptions.Add(x.ToSortOption());
+            }
+            m_config.PotentialFilterConfig = Filter.GetConfig();
+        }
+    }
+}

--- a/Cindeck/ViewModels/UnitViewModel.cs
+++ b/Cindeck/ViewModels/UnitViewModel.cs
@@ -263,7 +263,8 @@ namespace Cindeck.ViewModels
 
         public void OnActivate()
         {
-            
+            Idols.Refresh();
+            TemporalUnit.Timestamp = DateTime.Now;
         }
 
         public void OnDeactivate()

--- a/Cindeck/Views/MainView.xaml
+++ b/Cindeck/Views/MainView.xaml
@@ -18,6 +18,9 @@
             <TabItem Header="所属アイドル">
                 <local:OwnedIdolView DataContext="{Binding Path=OwnedIdol}"/>
             </TabItem>
+            <TabItem Header="ポテンシャル">
+                <local:PotentialView DataContext="{Binding Path=Potential}"/>
+            </TabItem>
             <TabItem Header="ユニット編成">
                 <local:UnitView DataContext="{Binding Path=Units}"/>
             </TabItem>

--- a/Cindeck/Views/PotentialView.xaml
+++ b/Cindeck/Views/PotentialView.xaml
@@ -1,0 +1,34 @@
+﻿<UserControl x:Class="Cindeck.Views.PotentialView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Cindeck.Views"
+              xmlns:c="clr-namespace:Cindeck.Controls"
+             mc:Ignorable="d" >
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Resources.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <DockPanel LastChildFill="True">
+        <c:IdolFilterPanel Margin="0,5,0,5" DockPanel.Dock="Top" DataContext="{Binding Filter}"/>
+        <c:SelectedItemBindableDataGrid ItemsSource="{Binding Path=PotentialData, IsAsync=True}" AutoGenerateColumns="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.Row="0">
+            <DataGrid.RowStyle>
+                <Style TargetType="DataGridRow">
+                    <Setter Property="Background" Value="{Binding Category, Converter={StaticResource IdolTypeToColorConverter}}"/>
+                </Style>
+            </DataGrid.RowStyle>
+            <DataGrid.Columns>
+                <DataGridTextColumn IsReadOnly="True" Header="名前" SortMemberPath="Name" Binding="{Binding Path=Name}"/>
+                <DataGridTextColumn IsReadOnly="True" Header="タイプ" Binding="{Binding Path=Category, Converter={StaticResource IdolCategoryConverter}}"/>
+                <DataGridComboBoxColumn Header="ボーカル" ItemsSource="{StaticResource PotentialLevels}" SelectedItemBinding="{Binding Path=Vocal, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                <DataGridComboBoxColumn Header="ダンス" ItemsSource="{StaticResource PotentialLevels}" SelectedItemBinding="{Binding Path=Dance, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                <DataGridComboBoxColumn Header="ビジュアル" ItemsSource="{StaticResource PotentialLevels}" SelectedItemBinding="{Binding Path=Visual, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                <DataGridComboBoxColumn Header="ライフ" ItemsSource="{StaticResource PotentialLevels}" SelectedItemBinding="{Binding Path=Life, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+            </DataGrid.Columns>
+        </c:SelectedItemBindableDataGrid>
+    </DockPanel>
+</UserControl>

--- a/Cindeck/Views/PotentialView.xaml
+++ b/Cindeck/Views/PotentialView.xaml
@@ -15,7 +15,7 @@
     </UserControl.Resources>
     <DockPanel LastChildFill="True">
         <c:IdolFilterPanel Margin="0,5,0,5" DockPanel.Dock="Top" DataContext="{Binding Filter}"/>
-        <c:SelectedItemBindableDataGrid ItemsSource="{Binding Path=PotentialData, IsAsync=True}" AutoGenerateColumns="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Grid.Row="0">
+        <c:SelectedItemBindableDataGrid ItemsSource="{Binding Path=PotentialData, IsAsync=True}" CanUserAddRows="False" AutoGenerateColumns="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
             <DataGrid.RowStyle>
                 <Style TargetType="DataGridRow">
                     <Setter Property="Background" Value="{Binding Category, Converter={StaticResource IdolTypeToColorConverter}}"/>

--- a/Cindeck/Views/PotentialView.xaml.cs
+++ b/Cindeck/Views/PotentialView.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Cindeck.Views
+{
+    /// <summary>
+    /// PotentialView.xaml の相互作用ロジック
+    /// </summary>
+    public partial class PotentialView : UserControl
+    {
+        public PotentialView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Cindeck/Views/SimulationView.xaml
+++ b/Cindeck/Views/SimulationView.xaml
@@ -17,151 +17,162 @@
     <Grid>
         <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
             <DockPanel LastChildFill="True">
-            <StackPanel DockPanel.Dock="Top">
-                <StackPanel Orientation="Horizontal">
-                    <Label Content="ユニット" Width="80"/>
-                    <ComboBox Grid.Row="0" Grid.Column="1" MinWidth="100" DisplayMemberPath="Name" ItemsSource="{Binding Units}" SelectedItem="{Binding Simulator.Unit, Mode=TwoWay}" HorizontalAlignment="Left" />
-                    <StackPanel Orientation="Horizontal" Visibility="{Binding Simulator.Unit, Converter={StaticResource NullToCollapsedConverter}}">
-                        <Label Content="センター効果" FontWeight="Bold"/>
-                        <Label Content="{Binding Simulator.Unit.Center.CenterEffect, FallbackValue=なし, Converter={StaticResource CenterEffectConverter}}"/>
+                <StackPanel DockPanel.Dock="Top">
+                    <StackPanel Orientation="Horizontal">
+                        <Label Content="ユニット" Width="80"/>
+                        <ComboBox Grid.Row="0" Grid.Column="1" MinWidth="100" DisplayMemberPath="Name" ItemsSource="{Binding Units}" SelectedItem="{Binding Simulator.Unit, Mode=TwoWay}" HorizontalAlignment="Left" />
+                        <StackPanel Orientation="Horizontal" Visibility="{Binding Simulator.Unit, Converter={StaticResource NullToCollapsedConverter}}">
+                            <Label Content="センター効果" FontWeight="Bold"/>
+                            <Label Content="{Binding Simulator.Unit.Center.CenterEffect, FallbackValue=なし, Converter={StaticResource CenterEffectConverter}}"/>
+                        </StackPanel>
                     </StackPanel>
-                </StackPanel>
-                <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
-                    <Label Content="楽曲"  Width="80"/>
-                    <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="1">
-                        <ComboBox MinWidth="200" IsEditable="True" ItemsSource="{Binding Songs}" SelectedItem="{Binding Simulator.Song, Mode=TwoWay}" DisplayMemberPath="Title" />
-                        <ComboBox Margin="5,0,0,0" DisplayMemberPath="Difficulty"
+                    <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
+                        <Label Content="楽曲"  Width="80"/>
+                        <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="1">
+                            <ComboBox MinWidth="200" IsEditable="True" ItemsSource="{Binding Songs}" SelectedItem="{Binding Simulator.Song, Mode=TwoWay}" DisplayMemberPath="Title" />
+                            <ComboBox Margin="5,0,0,0" DisplayMemberPath="Difficulty"
                            MinWidth="100" HorizontalAlignment="Left"
                            ItemsSource="{Binding Simulator.SongDataList}" SelectedItem="{Binding Simulator.SongData, Mode=TwoWay}"/>
-                        <Button Margin="5,0,0,0" Command="{Binding LoadSongsCommand}" Content="Wikiから取り込む"></Button>
+                            <Button Margin="5,0,0,0" Command="{Binding LoadSongsCommand}" Content="Wikiから取り込む"></Button>
+                        </StackPanel>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Grid.Row="3" Visibility="{Binding Simulator.SongData, Converter={StaticResource NullToCollapsedConverter}}">
+                        <Label Content="タイプ" FontWeight="Bold"/>
+                        <Label Content="{Binding Simulator.Song.Type, Converter={StaticResource IdolCategoryToSongTypeConverter}}"/>
+                        <Label Content="Lv"  FontWeight="Bold"/>
+                        <Label Content="{Binding Simulator.SongData.Level}"/>
+                        <Label Content="ノーツ数" FontWeight="Bold"/>
+                        <Label Content="{Binding Simulator.SongData.Notes}"/>
+                        <Label Content="時間(秒)" FontWeight="Bold"/>
+                        <Label Content="{Binding Simulator.SongData.Duration}"/>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal"  Margin="0,5,0,0">
+                        <Label Content="Groove Burst"  Grid.Row="4" Grid.Column="0"/>
+                        <ComboBox ItemsSource="{Binding GrooveBursts}" SelectedValue="{Binding Simulator.GrooveBurst}" DisplayMemberPath="Item2" SelectedValuePath="Item1"  Grid.Row="4" Grid.Column="1" MinWidth="100" HorizontalAlignment="Left"/>
+                        <ComboBox Visibility="{Binding Simulator.GrooveBurst, Converter={StaticResource NullToCollapsedConverter}}" Margin="5,0,0,0" ItemsSource="{Binding GrooveTypes}" SelectedValue="{Binding Simulator.GrooveType}" DisplayMemberPath="Item2" SelectedValuePath="Item1"  Grid.Row="4" Grid.Column="1" MinWidth="100" HorizontalAlignment="Left"/>
+                        <!--<CheckBox Visibility="{Binding Simulator.GrooveBurst, Converter={StaticResource NullToCollapsedConverter}}" Margin="5,5,0,0" Content="アンコール (Groove属性ボーナスの代わりに選んだ曲の属性ボーナスを適用する)" IsChecked="{Binding Simulator.IsEncore, Mode=TwoWay}"/>-->
                     </StackPanel>
                 </StackPanel>
-                <StackPanel Orientation="Horizontal" Grid.Row="3" Visibility="{Binding Simulator.SongData, Converter={StaticResource NullToCollapsedConverter}}">
-                    <Label Content="タイプ" FontWeight="Bold"/>
-                    <Label Content="{Binding Simulator.Song.Type, Converter={StaticResource IdolCategoryToSongTypeConverter}}"/>
-                    <Label Content="Lv"  FontWeight="Bold"/>
-                    <Label Content="{Binding Simulator.SongData.Level}"/>
-                    <Label Content="ノーツ数" FontWeight="Bold"/>
-                    <Label Content="{Binding Simulator.SongData.Notes}"/>
-                    <Label Content="時間(秒)" FontWeight="Bold"/>
-                    <Label Content="{Binding Simulator.SongData.Duration}"/>
-                </StackPanel>
-                <StackPanel Orientation="Horizontal"  Margin="0,5,0,0">
-                    <Label Content="Groove Burst"  Grid.Row="4" Grid.Column="0"/>
-                    <ComboBox ItemsSource="{Binding GrooveBursts}" SelectedValue="{Binding Simulator.GrooveBurst}" DisplayMemberPath="Item2" SelectedValuePath="Item1"  Grid.Row="4" Grid.Column="1" MinWidth="100" HorizontalAlignment="Left"/>
-                    <ComboBox Visibility="{Binding Simulator.GrooveBurst, Converter={StaticResource NullToCollapsedConverter}}" Margin="5,0,0,0" ItemsSource="{Binding GrooveTypes}" SelectedValue="{Binding Simulator.GrooveType}" DisplayMemberPath="Item2" SelectedValuePath="Item1"  Grid.Row="4" Grid.Column="1" MinWidth="100" HorizontalAlignment="Left"/>
-                    <!--<CheckBox Visibility="{Binding Simulator.GrooveBurst, Converter={StaticResource NullToCollapsedConverter}}" Margin="5,5,0,0" Content="アンコール (Groove属性ボーナスの代わりに選んだ曲の属性ボーナスを適用する)" IsChecked="{Binding Simulator.IsEncore, Mode=TwoWay}"/>-->
-                </StackPanel>
-            </StackPanel>
-            <StackPanel Margin="0,5,0,0" Orientation="Vertical" DockPanel.Dock="Top">
-                <StackPanel Orientation="Horizontal">
-                    <CheckBox VerticalAlignment="Center" Content="ゲスト" IsChecked="{Binding EnableGuest, Mode=TwoWay}" />
-                    <TextBox FontWeight="Bold" VerticalContentAlignment="Center" Margin="5,0,0,0" Style="{StaticResource PlaceHolder}" Visibility="{Binding EnableGuest, Converter={StaticResource BooleanToVisibilityConverter}}" Tag="ゲストセンターのIID"  Width="135" Text="{Binding GuestIid, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IidConverter}}"/>
-                    <StackPanel Orientation="Horizontal" Visibility="{Binding EnableGuest, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <Label Content="{Binding Simulator.Guest, Converter={StaticResource IdolConverter}}" FontWeight="Bold"/>
-                        <Label Visibility="{Binding Simulator.Guest.CenterEffect, Converter={StaticResource NullToCollapsedConverter}}" Content="{Binding Simulator.Guest.CenterEffect, Converter={StaticResource CenterEffectConverter}}"/>
-                    </StackPanel>
-                </StackPanel>
-                <CheckBox  Margin="0,5,0,0" Content="ルーム効果(全アイドルの全アピール値10%アップ)" IsChecked="{Binding Simulator.EnableRoomEffect, Mode=TwoWay}"/>
-                <CheckBox  Margin="0,5,0,0" Content="サポートメンバー(自動的に所属アイドルから選びます)" IsChecked="{Binding Simulator.EnableSupportMembers, Mode=TwoWay}" />
-                <StackPanel Visibility="{Binding Simulator.EnableSupportMembers, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <ItemsControl ItemsSource="{Binding Simulator.SupportMembers}">
-                        <ItemsControl.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <WrapPanel Orientation="Horizontal" />
-                            </ItemsPanelTemplate>
-                        </ItemsControl.ItemsPanel>
-                        <ItemsControl.Template>
-                            <ControlTemplate TargetType="ItemsControl">
-                                <ItemsPresenter Margin="5" />
-                            </ControlTemplate>
-                        </ItemsControl.Template>
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <Button Tag="{Binding Path=., Mode=OneWay}" VerticalAlignment="Center" HorizontalAlignment="Left"  Margin="5" Background="{Binding Category, Converter={StaticResource IdolTypeToColorConverter}}">
-                                    <Button.Content>
-                                        <Label HorizontalAlignment="Left" Content="{Binding Path=., Mode=OneWay, Converter={StaticResource UnitSlotConverter}}" />
-                                    </Button.Content>
-                                </Button>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
+                <StackPanel Margin="0,5,0,0" Orientation="Vertical" DockPanel.Dock="Top">
                     <StackPanel Orientation="Horizontal">
-                        <Label Content="サポートメンバーの合計アピール" FontWeight="Bold" />
-                        <Label Content="{Binding Simulator.SupportMemberAppeal}"/>
+                        <CheckBox VerticalAlignment="Center" Content="ゲスト" IsChecked="{Binding EnableGuest, Mode=TwoWay}" />
+                        <TextBox FontWeight="Bold" VerticalContentAlignment="Center" Margin="5,0,0,0" Style="{StaticResource PlaceHolder}" Visibility="{Binding EnableGuest, Converter={StaticResource BooleanToVisibilityConverter}}" Tag="ゲストセンターのIID"  Width="135" Text="{Binding GuestIid, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, Converter={StaticResource IidConverter}}"/>
+                        <StackPanel Orientation="Horizontal" Visibility="{Binding EnableGuest, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <Label Content="{Binding Simulator.Guest, Converter={StaticResource IdolConverter}}" FontWeight="Bold"/>
+                            <Label Visibility="{Binding Simulator.Guest.CenterEffect, Converter={StaticResource NullToCollapsedConverter}}" Content="{Binding Simulator.Guest.CenterEffect, Converter={StaticResource CenterEffectConverter}}"/>
+                        </StackPanel>
                     </StackPanel>
-                </StackPanel>
-                <StackPanel Orientation="Horizontal">
-                    <Label Content="合計アピール"  FontWeight="Bold" />
-                    <Label Content="{Binding Simulator.TotalAppeal}"/>
-                    <Label Content="ライフ"  FontWeight="Bold" />
-                    <Label Content="{Binding Simulator.Life}"/>
-                </StackPanel>
-                <StackPanel  Margin="0,5,0,5" Orientation="Horizontal">
-                    <Label Content="特技発動率"  Grid.Row="4" Grid.Column="0"/>
-                    <ComboBox ItemsSource="{Binding SkillControls}" SelectedValue="{Binding Simulator.SkillControl}" DisplayMemberPath="Item2" SelectedValuePath="Item1" MinWidth="100" HorizontalAlignment="Left"/>
-                </StackPanel>
-                <Button HorizontalAlignment="Left" Content="実行" Command="{Binding StartSimulationCommand}" Width="200"/>
-                <StackPanel  x:Name="ResultPanel"  Visibility="{Binding Simulator.ResultsUpToDate, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <Label DockPanel.Dock="Top" Content="※結果はALL PERFECTの場合のスコアで、ノーツの密度の変化は計算に入れていません"/>
+                    <StackPanel Margin="0,5,0,0" Orientation="Horizontal" Visibility="{Binding EnableGuest, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <Label Content="ポテンシャル" FontWeight="Bold"/>
+                        <Label Content="ボーカル"/>
+                        <ComboBox ItemsSource="{StaticResource PotentialLevels}" MinWidth="50" SelectedItem="{Binding Simulator.GuestPotential.Vocal}"/>
+                        <Label Content="ダンス"/>
+                        <ComboBox ItemsSource="{StaticResource PotentialLevels}" MinWidth="50" SelectedItem="{Binding Simulator.GuestPotential.Dance}"/>
+                        <Label Content="ビジュアル"/>
+                        <ComboBox ItemsSource="{StaticResource PotentialLevels}" MinWidth="50" SelectedItem="{Binding Simulator.GuestPotential.Visual}"/>
+                        <Label Content="ライフ"/>
+                        <ComboBox ItemsSource="{StaticResource PotentialLevels}" MinWidth="50" SelectedItem="{Binding Simulator.GuestPotential.Life}"/>
+                    </StackPanel>
+                    <CheckBox  Margin="0,5,0,0" Content="ルーム効果(全アイドルの全アピール値10%アップ)" IsChecked="{Binding Simulator.EnableRoomEffect, Mode=TwoWay}"/>
+                    <CheckBox  Margin="0,5,0,0" Content="サポートメンバー(自動的に所属アイドルから選びます)" IsChecked="{Binding Simulator.EnableSupportMembers, Mode=TwoWay}" />
+                    <StackPanel Visibility="{Binding Simulator.EnableSupportMembers, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <ItemsControl ItemsSource="{Binding Simulator.SupportMembers}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <WrapPanel Orientation="Horizontal" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.Template>
+                                <ControlTemplate TargetType="ItemsControl">
+                                    <ItemsPresenter Margin="5" />
+                                </ControlTemplate>
+                            </ItemsControl.Template>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Button Tag="{Binding Path=., Mode=OneWay}" VerticalAlignment="Center" HorizontalAlignment="Left"  Margin="5" Background="{Binding Category, Converter={StaticResource IdolTypeToColorConverter}}">
+                                        <Button.Content>
+                                            <Label HorizontalAlignment="Left" Content="{Binding Path=., Mode=OneWay, Converter={StaticResource UnitSlotConverter}}" />
+                                        </Button.Content>
+                                    </Button>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                        <StackPanel Orientation="Horizontal">
+                            <Label Content="サポートメンバーの合計アピール" FontWeight="Bold" />
+                            <Label Content="{Binding Simulator.SupportMemberAppeal}"/>
+                        </StackPanel>
+                    </StackPanel>
                     <StackPanel Orientation="Horizontal">
-                        <StackPanel DockPanel.Dock="Top" Margin="0,5,0,0" Orientation="Horizontal">
-                            <Label Content="スコア(平均)"  FontWeight="Bold" />
-                            <Label>
-                                <TextBlock>
+                        <Label Content="合計アピール"  FontWeight="Bold" />
+                        <Label Content="{Binding Simulator.TotalAppeal}"/>
+                        <Label Content="ライフ"  FontWeight="Bold" />
+                        <Label Content="{Binding Simulator.Life}"/>
+                    </StackPanel>
+                    <StackPanel  Margin="0,5,0,5" Orientation="Horizontal">
+                        <Label Content="特技発動率"  Grid.Row="4" Grid.Column="0"/>
+                        <ComboBox ItemsSource="{Binding SkillControls}" SelectedValue="{Binding Simulator.SkillControl}" DisplayMemberPath="Item2" SelectedValuePath="Item1" MinWidth="100" HorizontalAlignment="Left"/>
+                    </StackPanel>
+                    <Button HorizontalAlignment="Left" Content="実行" Command="{Binding StartSimulationCommand}" Width="200"/>
+                    <StackPanel  x:Name="ResultPanel"  Visibility="{Binding Simulator.ResultsUpToDate, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <Label DockPanel.Dock="Top" Content="※結果はALL PERFECTの場合のスコアで、ノーツの密度の変化は計算に入れていません"/>
+                        <StackPanel Orientation="Horizontal">
+                            <StackPanel DockPanel.Dock="Top" Margin="0,5,0,0" Orientation="Horizontal">
+                                <Label Content="スコア(平均)"  FontWeight="Bold" />
+                                <Label>
+                                    <TextBlock>
                         <Run Text="{Binding AverageScore}"></Run>
                         <Run>(1ノートあたり</Run>
                          <Run Text="{Binding AverageScorePerNote}"></Run>
                         <Run>)</Run>
-                                </TextBlock>
-                            </Label>
-                        </StackPanel>
-                        <StackPanel  DockPanel.Dock="Top" Margin="0,5,0,0" Orientation="Horizontal">
-                            <Label Content="スコア(最大)"  FontWeight="Bold" />
-                            <Label>
-                                <TextBlock>
+                                    </TextBlock>
+                                </Label>
+                            </StackPanel>
+                            <StackPanel  DockPanel.Dock="Top" Margin="0,5,0,0" Orientation="Horizontal">
+                                <Label Content="スコア(最大)"  FontWeight="Bold" />
+                                <Label>
+                                    <TextBlock>
                         <Run Text="{Binding MaxScore}"></Run>
                         <Run>(1ノートあたり</Run>
                          <Run Text="{Binding MaxScorePerNote}"></Run>
                         <Run>)</Run>
-                                </TextBlock>
-                            </Label>
-                        </StackPanel>
-                        <StackPanel  DockPanel.Dock="Top" Margin="0,5,0,0" Orientation="Horizontal">
-                            <Label Content="スコア(最小)"  FontWeight="Bold" />
-                            <Label>
-                                <TextBlock TextAlignment="Center">
+                                    </TextBlock>
+                                </Label>
+                            </StackPanel>
+                            <StackPanel  DockPanel.Dock="Top" Margin="0,5,0,0" Orientation="Horizontal">
+                                <Label Content="スコア(最小)"  FontWeight="Bold" />
+                                <Label>
+                                    <TextBlock TextAlignment="Center">
                         <Run Text="{Binding MinScore}"></Run>
                         <Run>(1ノートあたり</Run>
                         <Run Text="{Binding MinScorePerNote}"></Run>
                         <Run>)</Run>
-                                </TextBlock>
-                            </Label>
+                                    </TextBlock>
+                                </Label>
+                            </StackPanel>
                         </StackPanel>
-                    </StackPanel>
 
-                    <StackPanel  DockPanel.Dock="Top" Orientation="Horizontal"  Margin="0,5,0,0">
-                        <Label Content="結果の詳細" Grid.Row="4" Grid.Column="0"/>
-                        <ComboBox x:Name="SimulationResults" SelectedItem="{Binding SelectedResult, Mode=TwoWay}" ItemsSource="{Binding SimulationResults}" DisplayMemberPath="Name" Grid.Row="4" Grid.Column="1" MinWidth="100" HorizontalAlignment="Left"/>
-                    </StackPanel>
-                    <StackPanel  DockPanel.Dock="Top" Margin="0,5,0,0" Orientation="Horizontal">
-                        <Label Content="スコア"  FontWeight="Bold" />
-                        <Label>
-                            <TextBlock TextAlignment="Center">
+                        <StackPanel  DockPanel.Dock="Top" Orientation="Horizontal"  Margin="0,5,0,0">
+                            <Label Content="結果の詳細" Grid.Row="4" Grid.Column="0"/>
+                            <ComboBox x:Name="SimulationResults" SelectedItem="{Binding SelectedResult, Mode=TwoWay}" ItemsSource="{Binding SimulationResults}" DisplayMemberPath="Name" Grid.Row="4" Grid.Column="1" MinWidth="100" HorizontalAlignment="Left"/>
+                        </StackPanel>
+                        <StackPanel  DockPanel.Dock="Top" Margin="0,5,0,0" Orientation="Horizontal">
+                            <Label Content="スコア"  FontWeight="Bold" />
+                            <Label>
+                                <TextBlock TextAlignment="Center">
                         <Run Text="{Binding SelectedItem.Score, ElementName=SimulationResults}"></Run>
                         <Run>(1ノートあたり</Run>
                         <Run Text="{Binding SelectedItem.ScorePerNote, ElementName=SimulationResults}"></Run>
                         <Run>)</Run>
-                            </TextBlock>
-                        </Label>
-                        <Label Content="終了時のライフ"  FontWeight="Bold" />
-                        <Label Content="{Binding SelectedItem.RemainingLife, ElementName=SimulationResults}"/>
-                     </StackPanel>
+                                </TextBlock>
+                            </Label>
+                            <Label Content="終了時のライフ"  FontWeight="Bold" />
+                            <Label Content="{Binding SelectedItem.RemainingLife, ElementName=SimulationResults}"/>
+                        </StackPanel>
+                    </StackPanel>
                 </StackPanel>
-            </StackPanel>
-            <c:SkillTimeline Visibility="{Binding Visibility, ElementName=ResultPanel, Mode=OneWay}"
+                <c:SkillTimeline Visibility="{Binding Visibility, ElementName=ResultPanel, Mode=OneWay}"
                              DataContext="{Binding Simulator.Unit}" SimulationResult="{Binding SelectedItem,ElementName=SimulationResults}"/>
-        </DockPanel>
+            </DockPanel>
         </ScrollViewer>
     </Grid>
 </UserControl>


### PR DESCRIPTION
「ポテンシャル」タブにて所属アイドルのポテンシャル解放状況を設定できるようになりました。
アイドルのポテンシャルは「所属アイドル」タブ、「ユニット編成」タブ、および「シミュレーション」タブに反映されます。
ゲストのポテンシャルはシミュレーションを行う際に改めて設定する必要があります。
